### PR TITLE
Feature/support implicit object schema

### DIFF
--- a/examples/enums.json
+++ b/examples/enums.json
@@ -22,8 +22,7 @@
             "type": "boolean",
             "enum": [true, false]
           }
-        },
-        "type": "object"
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,18 @@
 {
   "name": "openapi-tsrf",
-  "version": "0.5.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-tsrf",
-      "version": "0.5.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.6.5",
         "change-case": "^4.1.2",
         "commander": "^9.4.0",
         "esm": "^3.2.25"
-      },
-      "bin": {
-        "openapi-tsrf": "bin/openapi-tsrf.js"
       },
       "devDependencies": {
         "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openapi-tsrf",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openapi-tsrf",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-tsrf",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Generates request factories for all discovered operations in an open api 3 document",
   "repository": "https://github.com/tristanmenzel/openapi-tsrf.git",
   "scripts": {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -29,6 +29,7 @@ program
         console.error(
           '"--openapi" must be present and point to a valid openapi file.',
         )
+        return
       }
 
       const openapiDoc = JSON.parse(fs.readFileSync(options.openapi, 'utf-8'))

--- a/src/cli/schemas.ts
+++ b/src/cli/schemas.ts
@@ -91,6 +91,9 @@ export function* getSchemaDefinition(
       yield DecIndent
       return
     }
+
+    if (schemaLooksLikeImplicitObjectType(schema)) schema.type = 'object'
+
     switch (schema.type) {
       case 'integer':
       case 'number':
@@ -136,4 +139,20 @@ export function* getSchemaDefinition(
   } finally {
     yield RestoreLineMode
   }
+}
+
+/**
+ * Some schemas don't explicitly set type=object, but if they list a set of properties then
+ * we should treat them as an object schema
+ * @param schema
+ */
+function schemaLooksLikeImplicitObjectType(
+  schema: Swagger.Schema3 | Swagger.BaseSchema,
+) {
+  const maybeObjSchema = schema as Swagger.Schema3
+  return (
+    schema.type === undefined &&
+    maybeObjSchema.properties !== undefined &&
+    Object.keys(maybeObjSchema.properties).length > 0
+  )
 }


### PR DESCRIPTION
Some object schemas omit "type":"object" however they should still be treated as objects