### PR TITLE
Treat schemas that don't declare a type as empty objects.

### DIFF
--- a/examples/empty-schemas.json
+++ b/examples/empty-schemas.json
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "version": "1.0.0",
+    "title": ""
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "EmptyType": {
+        "description": "I don't have a type"
+      },
+      "Director": {
+        "properties": {
+          "directorAddress": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/address"
+              },
+              {
+                "description": "The legal address of the director"
+              }
+            ]
+          }
+        }
+      },
+      "address": {
+        "type": "object",
+        "required": [
+          "streetName",
+          "streetNumber",
+          "streetType",
+          "state",
+          "city",
+          "postcode",
+          "country"
+        ],
+        "properties": {
+          "unitNumber": {
+            "type": "string",
+            "description": "The unit number for the address"
+          },
+          "streetNumber": {
+            "type": "string",
+            "description": "The addresses street number"
+          },
+          "streetName": {
+            "type": "string",
+            "description": "Name of the street"
+          },
+          "streetType": {
+            "type": "string",
+            "description": "The type of street, e.g court, lane, parade"
+          },
+          "city": {
+            "type": "string",
+            "description": "The city the entity was registered or resides in"
+          },
+          "state": {
+            "type": "string",
+            "description": "The state the trust was registered or resides in"
+          },
+          "postcode": {
+            "type": "string",
+            "description": "The postcode e.g. 2000"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/empty-schemas.ts
+++ b/examples/empty-schemas.ts
@@ -1,0 +1,15 @@
+/* eslint-disable */
+export type EmptyType = { /* empty object */ [key in never]: never }
+export type Director = {
+  directorAddress?: (address
+    & { /* empty object */ [key in never]: never })
+}
+export type address = {
+  unitNumber?: string
+  streetNumber: string
+  streetName: string
+  streetType: string
+  city: string
+  state: string
+  postcode: string
+}

--- a/package.cli.json
+++ b/package.cli.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-tsrf-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Generates request factories for all discovered operations in an open api 3 document",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/cli/schemas.ts
+++ b/src/cli/schemas.ts
@@ -136,6 +136,9 @@ export function* getSchemaDefinition(
         yield DecIndent
         yield '}'
         return
+      case undefined:
+        yield '{ /* empty object */ [key in never]: never }'
+        return
       default:
         throw new Error(
           `Unsupported schema: ${JSON.stringify(schema, undefined, 2)}`,

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -59,4 +59,7 @@ describe('Test examples', () => {
   it('yaml file', () => {
     testExample('uspto-yaml', writeActuals, 'yaml')
   })
+  it('empty-schemas', () => {
+    testExample('empty-schemas', writeActuals)
+  })
 })


### PR DESCRIPTION
This is to support a pattern where descriptions and validation constraints are merged in with an existing type using the allOf schema